### PR TITLE
fix: preserve security headers for all URL patterns in lighttpd

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -17,20 +17,20 @@ url.rewrite-once = (
 index-file.names = ( "index.html" )
 
 $HTTP["url"] =~ "^/index\.html$" {
-  setenv.add-response-header = (
+  setenv.add-response-header += (
     "Cache-Control" => "public, max-age=86400, s-maxage=60",
     "Link" => "<https://www.booqr.dk/>; rel=\"canonical\""
   )
 }
 
 $HTTP["url"] =~ "^/robots\.txt$" {
-  setenv.add-response-header = (
+  setenv.add-response-header += (
     "Cache-Control" => "public, max-age=86400"
   )
 }
 
 $HTTP["url"] =~ "^/(_app/immutable/.*|favicon\.ico)$" {
-  setenv.add-response-header = (
+  setenv.add-response-header += (
     "Cache-Control" => "public, max-age=31536000, immutable"
   )
 }


### PR DESCRIPTION
## Summary

- Conditional `setenv.add-response-header = (...)` blocks were **replacing** the global security headers for any URL matching `/index.html`, `/robots.txt`, or `/_app/immutable/*`
- Changed `=` to `+=` in all three conditional blocks so per-URL `Cache-Control`/`Link` headers are **merged** with the global security headers instead of clobbering them

## Test plan

- [ ] Rebuild and deploy the Docker image
- [ ] `curl -I https://www.booqr.dk/` — verify security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Content-Security-Policy`, etc.) are present
- [ ] `curl -I https://www.booqr.dk/index.html` — verify both `Cache-Control` and security headers are present
- [ ] `curl -I https://www.booqr.dk/robots.txt` — verify both `Cache-Control` and security headers are present
- [ ] `curl -I https://www.booqr.dk/favicon.ico` — verify both `Cache-Control` and security headers are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)