### PR TITLE
chore: simplify CLAUDE.md to reference AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,3 @@
-# Project Instructions
+# Klinkby.Booqr-App - Claude AI Instructions
 
-**IMPORTANT**: All project guidelines and instructions are maintained in `AGENTS.md`.
-
-Please read `AGENTS.md` for comprehensive instructions on:
-
-- Framework and technology choices (Svelte 5, SvelteKit, Tailwind CSS)
-- API client configuration and authentication patterns
-- Security considerations and OWASP compliance
-- Application structure and routing conventions
-- Reusable components and CRUD patterns
-- Semantic HTML5 and accessibility requirements
-- Testing principles with Playwright
-
-## DO NOT MODIFY THIS FILE
-
-This file (`CLAUDE.md`) serves only as a pointer to `AGENTS.md` and should not be modified.
-
-**All project instructions, guidelines, and conventions MUST be added to `AGENTS.md`, not this file.**
-
-If you need to update project guidelines, edit `AGENTS.md` instead.
+@AGENTS.md


### PR DESCRIPTION
## Summary

Consolidate project instructions into a single file by reducing CLAUDE.md to a pointer to AGENTS.md, which contains all comprehensive guidelines.

## Changes

- Simplified `CLAUDE.md` to reference `AGENTS.md` only
- Removes redundant documentation pointer text
- All actual guidelines remain in `AGENTS.md`

## Test plan

- [ ] Verify CLAUDE.md loads correctly with the reference
- [ ] Confirm AGENTS.md contains all expected guidelines
- [ ] Check that project setup and workflow documentation is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)