### PR TITLE
fix(csp): drop gravatar, tighten img-src, add style-src-attr

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -37,7 +37,7 @@ $HTTP["url"] =~ "^/(_app/immutable/.*|favicon\.ico)$" {
 
 # Security headers
 setenv.add-response-header += (
-  "Content-Security-Policy" => "default-src 'self'; frame-src 'none'; img-src 'self' data: https://gravatar.com; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+  "Content-Security-Policy" => "default-src 'self'; frame-src 'none'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-attr: 'unsafe-inline'",
   "X-Frame-Options" => "DENY",
   "X-Content-Type-Options" => "nosniff",
   "Referrer-Policy" => "same-origin",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,10 +7,11 @@ const config = {
 		csp: {
 			directives: {
 				'default-src': ['self'],
-				'script-src': ['self', 'unsafe-inline'],
-				'img-src': ['self', 'data:', 'https://gravatar.com'],
-				'object-src': ['none'],
 				'frame-src': ['none'],
+				'img-src': ['self', 'data:'],
+				'object-src': ['none'],
+				'script-src': ['self', 'unsafe-inline'],
+				'style-src': ['self', 'unsafe-inline', 'unsafe-hashes'],
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

- Remove `gravatar.com` from `img-src` — no longer referenced anywhere in the app
- Add `unsafe-hashes` to `style-src` to allow inline styles from the event-calendar library
- Add `style-src-attr` directive to `lighttpd.conf` for consistency
- Align `lighttpd.conf` security headers with `svelte.config.js` CSP directives

## Test plan

- [ ] App loads without CSP violations in browser console
- [ ] Calendar page renders correctly (event-calendar inline styles not blocked)
- [ ] No gravatar image requests are made