### PR TITLE
chore(deps): bump actions/checkout from v6 to v6.0.2

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: anthropics/claude-code-action@v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-tml:        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+tml:        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
Replaces the conflicted Dependabot PR #140, which could not be auto-rebased because PR #135 (claude-code-action bump) had already modified `claude.yml`.\n\nApplies the same two-line change from #140 on top of current main:\n- `.github/workflows/claude.yml`: `actions/checkout@v6` → `v6.0.2`\n- `.github/workflows/docker-image.yml`: `actions/checkout@v6` → `v6.0.2`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS6ehC4vsCapnr2xGQomLH)_