### PR TITLE
fix: remove nbf check that broke login (clock skew)

### DIFF
--- a/src/lib/auth.svelte.js
+++ b/src/lib/auth.svelte.js
@@ -101,8 +101,5 @@ function validate(tokenObj) {
 	if (!tokenObj.exp || typeof tokenObj.exp !== 'number') return false;
 	const now = Math.floor(Date.now() / 1000);
 
-	if (tokenObj.exp <= now) return false;
-	if (typeof tokenObj.nbf === 'number' && tokenObj.nbf > now) return false;
-
-	return true;
+	return tokenObj.exp > now;
 }


### PR DESCRIPTION
## Problem

Every login attempt shows "Authentication failed. Please try again." after the security-review changes landed.

## Root cause

The `nbf` (not-before) check added in the security review rejects tokens where the server clock is even 1 second ahead of the browser. The login page sets `auth.accessToken = response.access_token`, which calls `validate()`. If `nbf > client_now`, `validate()` returns `false`, `#token` is set to `null`, `auth.isLoggedIn` stays `false`, and the login page shows the error.

## Fix

Remove the `nbf` check. Client-side JWT validation is advisory UI-only; the server enforces `nbf` on every API call. There is no client-side security value in rejecting a token the server just issued.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WS6ehC4vsCapnr2xGQomLH)_