### PR TITLE
chore(deps-dev): bump prettier-plugin-svelte from 4.1.0 to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"globals": "^17.6.0",
 				"openapi-typescript-codegen": "^0.30.0",
 				"prettier": "^3.8.3",
-				"prettier-plugin-svelte": "^4.1.0",
+				"prettier-plugin-svelte": "^4.1.1",
 				"tailwindcss": "^4.2.2",
 				"typescript": "^6.0.3",
 				"vite": "^8.0.16"
@@ -2527,9 +2527,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-svelte": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.0.tgz",
-			"integrity": "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+			"integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"globals": "^17.6.0",
 		"openapi-typescript-codegen": "^0.30.0",
 		"prettier": "^3.8.3",
-		"prettier-plugin-svelte": "^4.1.0",
+		"prettier-plugin-svelte": "^4.1.1",
 		"tailwindcss": "^4.2.2",
 		"typescript": "^6.0.3",
 		"vite": "^8.0.16"


### PR DESCRIPTION
Dependency update for prettier-plugin-svelte

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdqweT8mXfQjJauvSgM3rP)_