### PR TITLE
Add booking notes, service descriptions, and local API dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
+    "dev:local": "API_LOCAL=1 vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-    "dev:local": "API_LOCAL=1 vite dev",
+		"dev:local": "API_LOCAL=1 vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/src/lib/api/models/AddServiceRequest.js
+++ b/src/lib/api/models/AddServiceRequest.js
@@ -3,6 +3,7 @@
  * @property {string} name
  * @property {string} duration
  * @property {any[] | null} employees
+ * @property {string | null} [description]
  */
 
 export {};

--- a/src/lib/api/models/Service.js
+++ b/src/lib/api/models/Service.js
@@ -3,6 +3,7 @@
  * @property {string} name
  * @property {string} duration
  * @property {Array<number | string>} employees
+ * @property {string | null} [description]
  * @property {number | string} [id]
  * @property {string} [created]
  * @property {string | null} [deleted]

--- a/src/lib/api/models/UpdateServiceRequest.js
+++ b/src/lib/api/models/UpdateServiceRequest.js
@@ -4,6 +4,7 @@
  * @property {string} name
  * @property {string} duration
  * @property {any[] | null} employees
+ * @property {string | null} [description]
  */
 
 export {};

--- a/src/lib/api/services/UserService.js
+++ b/src/lib/api/services/UserService.js
@@ -47,7 +47,7 @@ export class UserService {
      * @param toTime
      * @param start
      * @param num
-     * @returns MyBooking OK
+     * @returns CollectionResponseOfMyBooking OK
      * @throws ApiError
      */
     static getMyBookings(id, fromTime, toTime, start, num) {

--- a/src/lib/components/BookingForm.svelte
+++ b/src/lib/components/BookingForm.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Form } from '$lib';
+	import { Form, LimitedTextarea } from '$lib';
 	import { DateUtils } from '$lib/dateUtils.js';
 
 	let {
@@ -11,6 +11,7 @@
 		locations = [],
 		serviceId = $bindable(''),
 		startTime = $bindable(''),
+		notes = $bindable(''),
 		error = null,
 		loading = false,
 		onsubmit,
@@ -29,6 +30,11 @@
 
 	const selectedService = $derived(services.find((s) => String(s.id) === serviceId));
 	const serviceDurationMinutes = $derived(selectedService ? parseDurationMinutes(selectedService.duration) : 0);
+	const serviceDurationDisplay = $derived(
+		serviceDurationMinutes > 0
+			? `${Math.floor(serviceDurationMinutes / 60)}:${String(serviceDurationMinutes % 60).padStart(2, '0')}`
+			: '',
+	);
 
 	const vacancyDate = $derived(vacancy ? DateUtils.toLocalDate(new Date(vacancy.startTime)) : '');
 	const vacancyStartTime = $derived(vacancy ? DateUtils.toLocalTime(new Date(vacancy.startTime)) : '');
@@ -74,6 +80,12 @@
 			startTime = timeSlots[0] ?? '';
 		}
 	});
+
+	function slotLabel(slot) {
+		if (!serviceDurationMinutes) return slot;
+		const end = new Date(new Date(vacancyDate + 'T' + slot).getTime() + serviceDurationMinutes * 60000);
+		return `${slot} - ${DateUtils.toLocalTime(end)}`;
+	}
 
 	const canDelete = $derived(isReadonly && !!ondelete && !!booking?.startTime);
 
@@ -131,10 +143,20 @@
 						<option value={String(service.id)}>{service.name}</option>
 					{/each}
 				</select>
+				{#if selectedService}
+					<div class="mt-1 text-sm text-gray-500">
+						{#if serviceDurationDisplay}
+							<p class="font-medium">Duration: {serviceDurationDisplay}</p>
+						{/if}
+						{#if selectedService.description}
+							<p class="whitespace-pre-line">{selectedService.description}</p>
+						{/if}
+					</div>
+				{/if}
 			</div>
 
 			<div>
-				<label class="block text-sm font-medium text-gray-700 mb-1" for="bookingStartTime"> Start Time </label>
+				<label class="block text-sm font-medium text-gray-700 mb-1" for="bookingStartTime"> Time </label>
 				<select
 					bind:value={startTime}
 					class="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
@@ -143,10 +165,16 @@
 					required
 				>
 					{#each timeSlots as slot (slot)}
-						<option value={slot}>{slot}</option>
+						<option value={slot}>{slotLabel(slot)}</option>
 					{/each}
 				</select>
 			</div>
+
+			<LimitedTextarea
+				id="bookingNotes"
+				label={employeeName ? `Notes for ${employeeName}` : 'Notes'}
+				bind:value={notes}
+			/>
 		{:else if isReadonly && booking}
 			<dl class="space-y-2 text-sm">
 				{#if booking.serviceName}

--- a/src/lib/components/LimitedTextarea.svelte
+++ b/src/lib/components/LimitedTextarea.svelte
@@ -1,0 +1,28 @@
+<script>
+	let {
+		value = $bindable(''),
+		id,
+		label,
+		name = id,
+		rows = 3,
+		maxlength = 2000,
+		countLast = 150,
+		disabled = false,
+	} = $props();
+</script>
+
+<div>
+	<label for={id} class="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+	<textarea
+		{id}
+		{name}
+		{rows}
+		{maxlength}
+		{disabled}
+		bind:value
+		class="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+	></textarea>
+	{#if value.length > maxlength - countLast}
+		<p class="mt-1 text-sm text-gray-500">{value.length}/{maxlength}</p>
+	{/if}
+</div>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,7 @@ export { apiErrorMessage } from './apiErrorMessage.js';
 export { default as DataTable } from './components/DataTable.svelte';
 export { default as PaginatedTable } from './components/PaginatedTable.svelte';
 export { default as Form } from './components/Form.svelte';
+export { default as LimitedTextarea } from './components/LimitedTextarea.svelte';
 export { default as Calendar } from './components/Calendar.svelte';
 export { default as VacancyForm } from './components/VacancyForm.svelte';
 export { default as PasswordReset } from './components/PasswordReset.svelte';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	let selectedBooking = $state(null);
 	let formServiceId = $state('');
 	let formStartTime = $state('');
+	let formNotes = $state('');
 	let formError = $state(null);
 	let formLoading = $state(false);
 
@@ -116,6 +117,7 @@
 		selectedBooking = null;
 		formMode = 'book';
 		formServiceId = '';
+		formNotes = '';
 		formStartTime = DateUtils.toLocalTime(new Date(vacancy.startTime));
 		formError = null;
 		showForm = true;
@@ -128,6 +130,7 @@
 			await home.addBooking({
 				vacancyId: selectedVacancy.id,
 				serviceId: formServiceId,
+				notes: formNotes || null,
 				startTime: new Date(
 					DateUtils.toLocalDate(new Date(selectedVacancy.startTime)) + 'T' + formStartTime,
 				).toISOString(),
@@ -188,6 +191,7 @@
 					locations={home.locations}
 					bind:serviceId={formServiceId}
 					bind:startTime={formStartTime}
+					bind:notes={formNotes}
 					error={formError}
 					loading={formLoading}
 					onsubmit={handleSubmit}

--- a/src/routes/admin/services/[id]/+page.svelte
+++ b/src/routes/admin/services/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Form, apiErrorMessage } from '$lib';
+	import { Form, LimitedTextarea, apiErrorMessage } from '$lib';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
@@ -13,6 +13,7 @@
 
 	let name = $state('');
 	let duration = $state('');
+	let description = $state('');
 	let selectedEmployeeIds = $state([]);
 	let error = $state(null);
 	let loading = $state(false);
@@ -38,6 +39,7 @@
 			const existing = await service.getService(id);
 			name = existing.name;
 			duration = existing.duration;
+			description = existing.description || '';
 			selectedEmployeeIds = (existing.employees || []).map(String);
 		} catch (err) {
 			error = apiErrorMessage(err);
@@ -50,7 +52,11 @@
 		error = null;
 		loading = true;
 		try {
-			await service.saveService({ id, isEdit, payload: { name, duration, employees: selectedEmployeeIds } });
+			await service.saveService({
+				id,
+				isEdit,
+				payload: { name, duration, description: description || null, employees: selectedEmployeeIds },
+			});
 			await goto(resolve('/admin/services'));
 		} catch (err) {
 			error = apiErrorMessage(err);
@@ -103,6 +109,8 @@
 						placeholder="e.g., 01:00:00"
 					/>
 				</div>
+
+				<LimitedTextarea id="description" label="Description" bind:value={description} />
 
 				<fieldset>
 					<legend class="block text-sm font-medium text-gray-700 mb-1">Employees</legend>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 const API_TARGET = 'https://www.booqr.dk';
+const LOCAL_API_TARGET = 'http://localhost:8080';
+const USE_LOCAL_API = !!process.env.API_LOCAL;
 const H1_HEADERS = new Set(['host', 'connection', 'transfer-encoding', 'keep-alive', 'upgrade']);
 
 /** Proxies an incoming HTTP/1.1 request to the upstream over HTTP/2. */
@@ -39,13 +41,16 @@ export default defineConfig({
 	oxc: {
 		target: 'es2022',
 	},
+	server: USE_LOCAL_API ? { proxy: { '/api': { target: LOCAL_API_TARGET, changeOrigin: true } } } : undefined,
 	plugins: [
-		{
-			name: 'h2-proxy',
-			configureServer(server) {
-				server.middlewares.use('/api', proxyToH2);
-			},
-		},
+		USE_LOCAL_API
+			? null
+			: {
+					name: 'h2-proxy',
+					configureServer(server) {
+						server.middlewares.use('/api', proxyToH2);
+					},
+				},
 		tailwindcss(),
 		sveltekit(),
 	],


### PR DESCRIPTION
## Summary
- Add `LimitedTextarea` component (char-count-limited textarea) and wire it into `BookingForm` (customer notes) and the admin service edit form (service description)
- `BookingForm`: show selected service's duration and description, and display end time alongside each start-time slot
- Home booking flow: pass `notes` through to `addBooking`
- Admin service form: persist `description` on save/load
- `getMyBookings`: fix return type to `CollectionResponseOfMyBooking`
- Add local API dev mode (`npm run dev:local` / `API_LOCAL=1`) proxying `/api` to `http://localhost:8080` instead of the H2 proxy to `www.booqr.dk`
- Minor CI workflow tweaks and dependency pin adjustment (`@sveltejs/kit`)

## Test plan
- [ ] `npm run lint`
- [ ] `npm run test:e2e`
- [ ] Manually verify booking form shows service description/duration and notes are saved
- [ ] Manually verify service description is saved/loaded in admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)